### PR TITLE
fix: bug two x in chrome

### DIFF
--- a/src/components/search/Search.vue
+++ b/src/components/search/Search.vue
@@ -212,6 +212,16 @@ export default {
     width: auto;
     min-width: 0;
     font-family: 'Libre Baskerville', serif;
+
+    // Hide browser's native search clear button
+    &::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+      appearance: none;
+    }
+
+    &::-ms-clear {
+      display: none;
+    }
   }
 
   &__results {


### PR DESCRIPTION
When browsing the map with chrome 142.0.7444.176 (Official Build) (64-bit) (cohort: Stable) , the search bar shows two "x", which is one to many. Keeping accessibility of the search field, just hiding via CSS, as the primary "X" is functionally equivalent.

Before:

<img width="406" height="62" alt="image" src="https://github.com/user-attachments/assets/f6047152-6d78-48e9-859e-a3ed0871c698" />

After:

<img width="417" height="63" alt="image" src="https://github.com/user-attachments/assets/1b2551cb-1fb1-4f19-8686-bde108afccd9" />
