### PR TITLE
fix: transparent mobile blue tap color

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -198,6 +198,7 @@ body {
   width: 100%;
   font-size: 16px;
   background: #002D55;
+  -webkit-tap-highlight-color: transparent;
 }
 
 #app {


### PR DESCRIPTION
This fixes a cosmetic issue on mobile where taps are highlighted in blue rectangles for a split second after tapping.

Before:

<img width="168" height="233" alt="image" src="https://github.com/user-attachments/assets/daebdff3-2a07-4917-b8be-8302ee39eb10" />


After:

<img width="78" height="113" alt="image" src="https://github.com/user-attachments/assets/e504ba30-de0c-4be7-9c0b-38df30068ef0" />
